### PR TITLE
Compile and run Lingo spec with Crystal 0.21

### DIFF
--- a/examples/hex_colors.cr
+++ b/examples/hex_colors.cr
@@ -10,26 +10,27 @@ module HexColors
 
   class Color
     property :red, :green, :blue
+
     def to_s
       "<Color red:#{red} green:#{green} blue:#{blue}>"
     end
   end
 
-
   class Parser < Lingo::Parser
     root(:color)
 
-    rule(:color) { hash_mark >> octet.as(:red) >> octet.as(:green) >> octet.as(:blue) }
+    rule(:color) { hash_mark >> octet.named(:red) >> octet.named(:green) >> octet.named(:blue) }
     rule(:hash_mark) { str("#") }
-    rule(:octet) { match(/[0-9A-f]{2}/i)}
+    rule(:octet) { match(/[0-9A-f]{2}/i) }
   end
-
 
   class Visitor < Lingo::Visitor
     getter :color
+
     def initialize
       @color = Color.new
     end
+
     enter(:red) {
       visitor.color.red = node.full_value.upcase
     }

--- a/examples/road_names.cr
+++ b/examples/road_names.cr
@@ -1,8 +1,8 @@
-
-
 module RoadNames
   class Road
     property :number, :interstate, :direction, :business
+    @number : Int32?
+    @direction : String?
     @interstate = false
     @business = false
   end
@@ -29,10 +29,10 @@ module RoadNames
     # Express optionality with `.maybe`
     # Name matched strings with `.as`
     rule(:road_name) {
-      interstate.as(:interstate).maybe >>
-        number.as(:number) >>
-        direction.as(:direction).maybe >>
-        business.as(:business).maybe
+      interstate.named(:interstate).maybe >>
+        number.named(:number) >>
+        direction.named(:direction).maybe >>
+        business.named(:business).maybe
     }
     # You MUST name a starting rule:
     root(:road_name)
@@ -40,6 +40,7 @@ module RoadNames
 
   class RoadVisitor < Lingo::Visitor
     getter :road
+
     def initialize
       @road = Road.new
     end
@@ -67,7 +68,7 @@ module RoadNames
   end
 
   def self.parse_road(input_str)
-    ast = RoadParser.parse(input_str)
+    ast = RoadParser.new.parse(input_str)
     visitor = RoadVisitor.new
     visitor.visit(ast)
     visitor.road

--- a/examples/slow_json.cr
+++ b/examples/slow_json.cr
@@ -2,7 +2,7 @@ require "../src/lingo"
 
 module SlowJSON
   def self.parse(input_string)
-    parse_result = JSONParser.parse(input_string)
+    parse_result = JSONParser.new.parse(input_string)
     visitor = JSONVisitor.new
     visitor.visit(parse_result)
     visitor.values.pop
@@ -14,42 +14,42 @@ module SlowJSON
 
     rule(:object) {
       (str("{") >> space? >>
-      (pair >> (comma >> pair).repeat(0)).maybe >>
-      space? >> str("}")).as(:object)
+        (pair >> (comma >> pair).repeat(0)).maybe >>
+        space? >> str("}")).named(:object)
     }
 
-    rule(:comma) { space? >> str(",") >> space?}
+    rule(:comma) { space? >> str(",") >> space? }
 
-    rule(:pair) { key.as(:key) >> kv_delimiter >> value.as(:value) }
+    rule(:pair) { key.named(:key) >> kv_delimiter >> value.named(:value) }
     rule(:kv_delimiter) { space? >> str(":") >> space? }
     rule(:key) { string }
     rule(:value) {
       string | float | integer |
-      object | array |
-      value_true | value_false | value_null
+        object | array |
+        value_true | value_false | value_null
     }
 
     rule(:array) {
       (str("[") >> space? >>
-      (
-        value.as(:value) >>
-        (comma >> value.as(:value)).repeat(0)
-      ).maybe >>
-      space? >> str("]")).as(:array)
+        (
+          value.named(:value) >>
+            (comma >> value.named(:value)).repeat(0)
+        ).maybe >>
+        space? >> str("]")).named(:array)
     }
 
     rule(:string) {
       str('"') >> (
         str("\\") >> any | str('"').absent >> any
-      ).repeat.as(:string) >> str('"')
+      ).repeat.named(:string) >> str('"')
     }
 
-    rule(:integer) { digits.as(:integer) }
-    rule(:float) { (digits >> str(".") >> digits).as(:float) }
+    rule(:integer) { digits.named(:integer) }
+    rule(:float) { (digits >> str(".") >> digits).named(:float) }
 
-    rule(:value_true) { str("true").as(:true) }
-    rule(:value_false) { str("false").as(:false) }
-    rule(:value_null) { str("null").as(:null) }
+    rule(:value_true) { str("true").named(:true) }
+    rule(:value_false) { str("false").named(:false) }
+    rule(:value_null) { str("null").named(:null) }
 
     rule(:digits) { match(/[0-9]+/) }
     rule(:space?) { match(/\s+/).maybe }
@@ -62,6 +62,7 @@ module SlowJSON
 
   class JSONVisitor < Lingo::Visitor
     getter :objects, :keys, :values
+
     def initialize
       @objects = [] of JSONResult | JSONArray
       @keys = [] of JSONKey

--- a/spec/examples/slow_json_spec.cr
+++ b/spec/examples/slow_json_spec.cr
@@ -20,7 +20,7 @@ describe "SlowJSON" do
       "d" => nil,
       "e" => 3.321,
       "f" => {"f1" => "f2"},
-      "g" => [1, nil, {"h" => "str"}]
+      "g" => [1, nil, {"h" => "str"}],
     }
 
     res.should eq(expected)

--- a/spec/lingo/ordered_choice_spec.cr
+++ b/spec/lingo/ordered_choice_spec.cr
@@ -1,9 +1,9 @@
 require "../spec_helper"
 
-SIXES_TERMINAL = Lingo::Terminal.new("66")
-SEVENS_TERMINAL = Lingo::Terminal.new("77")
-EIGHTS_TERMINAL = Lingo::Terminal.new("88")
-SEVENS_EIGHTS = Lingo::OrderedChoice.new(SEVENS_TERMINAL, EIGHTS_TERMINAL)
+SIXES_TERMINAL      = Lingo::Terminal.new("66")
+SEVENS_TERMINAL     = Lingo::Terminal.new("77")
+EIGHTS_TERMINAL     = Lingo::Terminal.new("88")
+SEVENS_EIGHTS       = Lingo::OrderedChoice.new(SEVENS_TERMINAL, EIGHTS_TERMINAL)
 SIXES_SEVENS_EIGHTS = Lingo::OrderedChoice.new(SIXES_TERMINAL, SEVENS_EIGHTS)
 
 describe "Lingo::OrderedChoice" do
@@ -22,7 +22,7 @@ describe "Lingo::OrderedChoice" do
     it "applies the first successful parse" do
       digit = math_parser.digit
       plus = math_parser.plus
-      d_or_p = (digit | plus).as(:d_or_p)
+      d_or_p = (digit | plus).named(:d_or_p)
 
       result = d_or_p.parse("+")
       result.full_value.should eq("+")

--- a/spec/lingo/parser_spec.cr
+++ b/spec/lingo/parser_spec.cr
@@ -31,10 +31,4 @@ describe "Lingo::Parser" do
       end
     end
   end
-
-  describe ".instance" do
-    it "memoizes an instance" do
-      Math::Parser.instance.should eq(Math::Parser.instance)
-    end
-  end
 end

--- a/spec/lingo/sequence_spec.cr
+++ b/spec/lingo/sequence_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 integer = Math.parser.integer
 operator = Math.parser.operator
-binary_expression = integer.as(:operand) >> operator >> integer.as(:operand)
+binary_expression = integer.named(:operand) >> operator >> integer.named(:operand)
 
 describe "Lingo::Sequence" do
   describe "#matches?" do
@@ -26,7 +26,7 @@ describe "Lingo::Sequence" do
       result.line.should eq(1)
       result.column.should eq(1)
       child_columns = result.children.map &.column
-      child_columns.should eq([1,4,5])
+      child_columns.should eq([1, 4, 5])
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -16,7 +16,7 @@ module Math
   end
 
   def self.parser
-    Math::Parser.instance
+    @@instance ||= Math::Parser.new
   end
 
   def self.visitor
@@ -25,19 +25,19 @@ module Math
 
   alias Operand = Int32
   alias BinaryOperation = (Int32, Int32) -> Int32
-  ADDITION = BinaryOperation.new { |left, right| left + right }
+  ADDITION       = BinaryOperation.new { |left, right| left + right }
   MULTIPLICATION = BinaryOperation.new { |left, right| left * right }
 
   class Parser < Lingo::Parser
     root(:expression)
     rule(:expression) {
-      integer.as(:operand) >>
+      integer.named(:operand) >>
         ws.repeat(0) >>
-        (operator >> ws.repeat(0) >>  integer.as(:operand) >> ws.repeat(0)).repeat(0)
+        (operator >> ws.repeat(0) >> integer.named(:operand) >> ws.repeat(0)).repeat(0)
     }
-    rule(:operator) { (plus.as(:plus) | times.as(:times))   }
+    rule(:operator) { (plus.named(:plus) | times.named(:times)) }
 
-    rule(:sign) { plus.as(:positive) | minus.as(:negative) }
+    rule(:sign) { plus.named(:positive) | minus.named(:negative) }
 
     rule(:plus) { str("+") }
     rule(:minus) { str("-") }
@@ -50,7 +50,7 @@ module Math
 
   class Visitor < Lingo::Visitor
     alias ValueStack = Array(Operand)
-    alias OperationStack =  Array(BinaryOperation)
+    alias OperationStack = Array(BinaryOperation)
     getter :values, :operations
 
     def initialize
@@ -61,10 +61,10 @@ module Math
     enter(:operand) {
       visitor.values << node.full_value.to_i
     }
-    enter(:plus)  {
+    enter(:plus) {
       visitor.operations << ADDITION
     }
-    enter(:times)  {
+    enter(:times) {
       visitor.operations << MULTIPLICATION
     }
 

--- a/src/lingo/context.cr
+++ b/src/lingo/context.cr
@@ -1,7 +1,7 @@
 class Lingo::Context
   property :remainder, :current_node, :root, :column, :line
 
-  def initialize(@remainder="", @root=nil, @column=1, @line=1)
+  def initialize(@remainder = "", @root = nil.as(Lingo::Node?), @column = 1, @line = 1)
   end
 
   def push_node(parsed_node)
@@ -16,7 +16,7 @@ class Lingo::Context
     nil
   end
 
-  def fork(root=nil)
+  def fork(root = nil)
     self.class.new(remainder: remainder, root: root, column: column, line: line)
   end
 

--- a/src/lingo/lazy_rule.cr
+++ b/src/lingo/lazy_rule.cr
@@ -1,6 +1,8 @@
 require "./rule"
+
 class LazyRule < Lingo::Rule
   alias RuleGenerator = Proc(Lingo::Rule)
+  @inner_rule : Lingo::Rule?
 
   def initialize(&rule_generator : RuleGenerator)
     @rule_generator = rule_generator
@@ -10,8 +12,8 @@ class LazyRule < Lingo::Rule
     inner_rule.parse?(raw_input)
   end
 
-  def as(name)
-    inner_rule.as(name)
+  def named(name)
+    inner_rule.named(name)
   end
 
   private def inner_rule

--- a/src/lingo/named_rule.cr
+++ b/src/lingo/named_rule.cr
@@ -1,7 +1,7 @@
 require "./rule"
 
 class Lingo::NamedRule < Lingo::Rule
-  def initialize(@name, @inner)
+  def initialize(@name : String | Symbol, @inner : Lingo::Rule)
   end
 
   def parse?(context : Lingo::Context)

--- a/src/lingo/node.cr
+++ b/src/lingo/node.cr
@@ -2,14 +2,14 @@ class Lingo::Node
   getter :value, :children, :line, :column
   property :name
 
-  def initialize(@value="", @children=[] of Lingo::Node, @name=nil, @line=0, @column=0)
+  def initialize(@value = "", @children = [] of Lingo::Node, @name = nil.as(String? | Symbol?), @line = 0, @column = 0)
   end
 
   def to_s
-    "<#{self.class.name} (#{@name}) value='#{value}' children=(#{children.map {|c| c.name.inspect as String}.join(", ")})>"
+    "<#{self.class.name} (#{@name}) value='#{value}' children=(#{children.map { |c| c.name.inspect as String }.join(", ")})>"
   end
 
   def full_value
-    @value + children.map { |c| c.full_value as String }.join("")
+    @value + children.map { |c| c.full_value.as(String) }.join("")
   end
 end

--- a/src/lingo/not_rule.cr
+++ b/src/lingo/not_rule.cr
@@ -1,7 +1,7 @@
 require "./rule"
 
 class Lingo::NotRule < Lingo::Rule
-  def initialize(@inner)
+  def initialize(@inner : Lingo::Rule)
   end
 
   def parse?(context : Lingo::Context)

--- a/src/lingo/ordered_choice.cr
+++ b/src/lingo/ordered_choice.cr
@@ -3,8 +3,9 @@ require "./rule"
 class Lingo::OrderedChoice < Lingo::Rule
   alias Choices = Array(Lingo::Rule)
   getter :choices
+  @choices : Choices
 
-  def initialize(incoming_choices=Choices.new)
+  def initialize(incoming_choices = Choices.new)
     new_choices = Choices.new
     incoming_choices.each do |incoming_choice|
       if incoming_choice.responds_to?(:choices)

--- a/src/lingo/parse_failed_exception.cr
+++ b/src/lingo/parse_failed_exception.cr
@@ -1,7 +1,7 @@
 class Lingo::ParseFailedException < Exception
   property :context
 
-  def initialize(@context)
+  def initialize(@context : Lingo::Context)
     super("Parse failed at #{position} (\"#{next_text(5)}\")")
   end
 

--- a/src/lingo/parser.cr
+++ b/src/lingo/parser.cr
@@ -13,13 +13,13 @@ class Lingo::Parser
 
   macro rule(rule_name, &block)
     def {{rule_name.id}}
-      @rules[{{rule_name}}] ||= LazyRule.new { ({{block.body}}) as Lingo::Rule }
+      @rules[{{rule_name}}] ||= LazyRule.new { ({{block.body}}).as(Lingo::Rule) }
     end
   end
 
   macro root(rule_name)
     def root
-      @root ||= {{rule_name.id}}.as({{rule_name}})
+      @root ||= {{rule_name.id}}.named({{rule_name}}).as(Lingo::Rule)
     end
 
     def parse(raw_input)
@@ -29,13 +29,5 @@ class Lingo::Parser
 
   def any
     @rules[:any] ||= match(/./)
-  end
-
-  def self.instance
-    @@instance ||= self.new
-  end
-
-  def self.parse(input_str)
-    instance.parse(input_str)
   end
 end

--- a/src/lingo/pattern_terminal.cr
+++ b/src/lingo/pattern_terminal.cr
@@ -6,7 +6,8 @@ class Lingo::PatternTerminal < Lingo::Rule
 
   def parse?(context : Lingo::Context)
     success = false
-    context.remainder.match(@pattern) do |match_data|
+    match_data = context.remainder.match(@pattern)
+    if match_data
       success = true
       match_string = match_data[0]
       match_node = Lingo::Node.new(value: match_string, line: context.line, column: context.column)

--- a/src/lingo/repeat.cr
+++ b/src/lingo/repeat.cr
@@ -1,5 +1,5 @@
 class Lingo::Repeat < Lingo::Rule
-  def initialize(@inner, @from=0, @to=Float32::INFINITY)
+  def initialize(@inner : Lingo::Rule, @from = 0, @to : (Float32 | Int32) = Float32::INFINITY)
   end
 
   def parse?(context : Lingo::Context)

--- a/src/lingo/rule.cr
+++ b/src/lingo/rule.cr
@@ -1,7 +1,6 @@
 require "./node"
 
 abstract class Lingo::Rule
-
   abstract def parse?(context : Lingo::Context)
 
   def parse(raw_input : String)
@@ -41,11 +40,11 @@ abstract class Lingo::Rule
     repeat(0, 1)
   end
 
-  def repeat(from=1, to=Float32::INFINITY)
+  def repeat(from = 1, to = Float32::INFINITY)
     Lingo::Repeat.new(self, from: from, to: to)
   end
 
-  def as(name)
+  def named(name)
     Lingo::NamedRule.new(name, self)
   end
 

--- a/src/lingo/sequence.cr
+++ b/src/lingo/sequence.cr
@@ -1,8 +1,9 @@
 class Lingo::Sequence < Lingo::Rule
   alias Parts = Array(Lingo::Rule)
   getter :parts
+  @parts : Parts
 
-  def initialize(incoming_parts=Parts.new, @name=nil)
+  def initialize(incoming_parts = Parts.new, @name = nil.as(String?))
     new_parts = Parts.new
     incoming_parts.each do |input|
       if input.is_a?(Lingo::Sequence)

--- a/src/lingo/string_terminal.cr
+++ b/src/lingo/string_terminal.cr
@@ -1,5 +1,6 @@
 class Lingo::StringTerminal < Lingo::Rule
   getter :search
+  @search : String
 
   def initialize(search : String | Char)
     @search = search.to_s

--- a/src/lingo/visitor.cr
+++ b/src/lingo/visitor.cr
@@ -1,8 +1,6 @@
 require "./node"
 
 class Lingo::Visitor
-
-
   macro create_registry
     HandlerRegistry.new do |h, k|
       new_list = HandlerList.new
@@ -11,13 +9,16 @@ class Lingo::Visitor
   end
 
   macro inherited
+    @@enter_handlers : HandlerRegistry
+    @@exit_handlers : HandlerRegistry
+
     alias Handler = Lingo::Node, self -> Nil
     alias HandlerList = Array(Handler)
     alias HandlerRegistry = Hash(Symbol, HandlerList)
+
     @@enter_handlers = create_registry
     @@exit_handlers = create_registry
   end
-
 
   macro enter(rule_name, &block)
     @@enter_handlers[{{rule_name}}] << Handler.new { |node, visitor|


### PR DESCRIPTION
Because of breaking changes in the Crystal compiler, Lingo could not compile.

I've addressed the major changes:

1. In Crystal `as` has been changed from a keyword to a method `.as()`. This conflicts with `Rule#as` which I renamed to `Rule#named`.
1. Crystal now requires a little more help with type annotations than before. Mostly in method declarations. I've added them where necessary.
1. The type of the class var `@@instance` in `Lingo::Parser` could also no longer be inferred. I could not add the type annotation. `self.class` just wouldn't cut it, since the macros were not expanded until Parser was subclassed. I ended up removing the singleton, since it's mostly convenience and can be implemented outside `Lingo::Parser`.
