### PR TITLE
Fix column reported for matches after the first line.

### DIFF
--- a/spec/lingo/parser_spec.cr
+++ b/spec/lingo/parser_spec.cr
@@ -17,7 +17,7 @@ describe "Lingo::Parser" do
 
     describe "on errors" do
       it "tells how far it got" do
-        expect_raises(Lingo::ParseFailedException, "at 3:15") do
+        expect_raises(Lingo::ParseFailedException, "at 3:16") do
           Math.parser.parse("1
           +
           3 + 3%%")

--- a/src/lingo/context.cr
+++ b/src/lingo/context.cr
@@ -38,7 +38,7 @@ class Lingo::Context
     @line += new_lines
 
     if new_lines > 0
-      @column = last_line.size
+      @column = last_line.size + 1
     else
       @column += last_line.size
     end


### PR DESCRIPTION
Before this fix, the columns reported for matches on the first line
started at `1` for the first column, but matches on subsequent lines
started at `0` for the first column.

This fix makes all lines consistently start at column `1`.